### PR TITLE
fix: handle quarantine duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.3.1] - 2024-10-16
+
+### Fixed
+
+- Handle when two files with the same name are put into quarantine
+
 ## [v0.3.0] - 2024-10-08
 
 ### Added

--- a/cmd/quarantine.go
+++ b/cmd/quarantine.go
@@ -52,16 +52,17 @@ var restorePattern = regexp.MustCompile(".*([0-9a-f]{64}).lock")
 var quarantineRestoreCmd = &cobra.Command{
 	Use:   "restore",
 	Short: "Restore quarantined files",
+	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		qa := scanner.NewQuarantineAction(gctx.cache, conf.Quarantine.Location, gctx.lock)
-		for _, sha := range args {
-			if strings.HasSuffix(sha, ".lock") {
-				ts := restorePattern.FindStringSubmatch(sha)
+		for _, id := range args {
+			if strings.HasSuffix(id, ".lock") {
+				ts := restorePattern.FindStringSubmatch(id)
 				if len(ts) == 2 {
-					sha = ts[1]
+					id = ts[1]
 				}
 			}
-			if err := qa.Restore(sha); err != nil {
+			if err := qa.Restore(id); err != nil {
 				return err
 			}
 		}

--- a/pkg/cache/mock.go
+++ b/pkg/cache/mock.go
@@ -20,6 +20,13 @@ func (m *MockCache) Get(id string) (*Entry, error) {
 	panic("GetMock not implemented")
 }
 
+func (m *MockCache) GetBySha256(id string) (*Entry, error) {
+	if m.GetMock != nil {
+		return m.GetMock(id)
+	}
+	panic("GetMock not implemented")
+}
+
 func (m *MockCache) Close() error {
 	if m.CloseMock != nil {
 		return m.CloseMock()

--- a/pkg/scanner/actions_test.go
+++ b/pkg/scanner/actions_test.go
@@ -493,7 +493,7 @@ func TestInformAction_Handle(t *testing.T) {
 					QuarantineLocation: "/tmp/q/test.lock",
 				},
 			},
-			wantOut: `file test_file.bin seems malicious [[eicar test_eicar]], it has been quarantine to /tmp/q/test.lock, it has been deleted`,
+			wantOut: `file test_file.bin seems malicious [[eicar test_eicar]], it has been quarantined to /tmp/q/test.lock, it has been deleted`,
 		},
 	}
 	for _, tt := range tests {
@@ -680,14 +680,15 @@ func TestQuarantineAction_Restore(t *testing.T) {
 						},
 					},
 				)
-				f, err := os.CreateTemp(tmpDir, "test_*.lock")
+				cacheName := cache.ComputeCacheID("test")
+				f, err := os.Create(fmt.Sprintf("%s/%s.lock", tmpDir, cacheName))
 				if err != nil {
 					t.Errorf("could not create test file, error: %s", err)
 					return
 				}
 				f.WriteString("test_content")
 				f.Close()
-				err = a.Restore(strings.TrimSuffix(filepath.Base(f.Name()), ".lock"))
+				err = a.Restore(cacheName)
 				if err != nil {
 					t.Errorf("QuarantineAction.Restore, error: %s", err)
 					return

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -379,7 +379,8 @@ func (c *Connector) handleFile(file string) (sumResult SummarizedGMalwareResult,
 	fileSHA256 := hex.EncodeToString(hash.Sum(nil))
 
 	// check if file has already been handle
-	entry, err := c.config.Cache.Get(fileSHA256)
+	// get result by sha instead of id because same files may have different ids (if different names)
+	entry, err := c.config.Cache.GetBySha256(fileSHA256)
 	switch {
 	case err == nil:
 		if entry.RestoredAt.UnixMilli() > 0 {

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -128,7 +128,7 @@ func TestNewConnector(t *testing.T) {
 
 				conn.Close()
 
-				if !strings.HasSuffix(buffer.String(), "3fc6540b6002f7622d978ea8c6fcb6a661089de0f4952f42390a694107269893.lock, it has been deleted\n") {
+				if !strings.HasSuffix(buffer.String(), fmt.Sprintf("%s.lock, it has been deleted\n", cache.ComputeCacheID(testFile2.Name()))) {
 					t.Errorf("invalid output: %v", buffer.String())
 				}
 			},
@@ -234,7 +234,7 @@ func TestNewConnector(t *testing.T) {
 
 				conn.Close()
 
-				if !strings.HasSuffix(buffer.String(), "3fc6540b6002f7622d978ea8c6fcb6a661089de0f4952f42390a694107269893.lock, it has been deleted\n") {
+				if !strings.HasSuffix(buffer.String(), fmt.Sprintf("%s.lock, it has been deleted\n", cache.ComputeCacheID(testFile.Name()))) {
 					t.Errorf("invalid output: %s", buffer.String())
 				}
 			},
@@ -368,7 +368,7 @@ func TestNewConnector(t *testing.T) {
 					t.Errorf("invalid output: %v", buffer.String())
 				}
 
-				if !strings.HasSuffix(buffer.String(), "e813f5023843f5d654f37032cd407c3e78c079b212eab6ab584262903f9c6d46.lock, it has been deleted\n") {
+				if !strings.HasSuffix(buffer.String(), fmt.Sprintf("%s.lock, it has been deleted\n", cache.ComputeCacheID(archive.Name()))) {
 					t.Errorf("invalid output: %v", buffer.String())
 				}
 			},
@@ -501,7 +501,7 @@ func TestNewConnector(t *testing.T) {
 					t.Errorf("invalid output: %v", buffer.String())
 				}
 
-				if !strings.HasSuffix(buffer.String(), "e813f5023843f5d654f37032cd407c3e78c079b212eab6ab584262903f9c6d46.lock, it has been deleted\n") {
+				if !strings.HasSuffix(buffer.String(), fmt.Sprintf("%s.lock, it has been deleted\n", cache.ComputeCacheID(archive.Name()))) {
 					t.Errorf("invalid output: %v", buffer.String())
 				}
 			},
@@ -594,7 +594,7 @@ func TestNewConnector(t *testing.T) {
 
 				conn.Close()
 
-				if !strings.HasSuffix(buffer.String(), "3fc6540b6002f7622d978ea8c6fcb6a661089de0f4952f42390a694107269893.lock, it has been deleted\n") {
+				if !strings.HasSuffix(buffer.String(), fmt.Sprintf("%s.lock, it has been deleted\n", cache.ComputeCacheID(testFile2.Name()))) {
 					t.Errorf("invalid output: %v", buffer.String())
 				}
 			},


### PR DESCRIPTION
When two identical files with different name/paths are put into quarantine, they're merged into the same cache entry. When restored, only one of those is actually restored.

This MR uses the sha256 of the fullpath of the file as a key instead of its sha256.